### PR TITLE
Android Editor: Fix themed icon

### DIFF
--- a/platform/android/java/editor/src/main/AndroidManifest.xml
+++ b/platform/android/java/editor/src/main/AndroidManifest.xml
@@ -29,7 +29,7 @@
 
     <application
         android:allowBackup="false"
-        android:icon="@mipmap/icon"
+        android:icon="@mipmap/themed_icon"
         android:label="${editorAppName}${editorBuildSuffix}"
         android:requestLegacyExternalStorage="true"
         android:theme="@style/GodotEditorSplashScreenTheme"
@@ -43,7 +43,7 @@
             android:name=".GodotEditor"
             android:configChanges="orientation|keyboardHidden|screenSize|smallestScreenSize|density|keyboard|navigation|screenLayout|uiMode"
             android:exported="true"
-            android:icon="@mipmap/icon"
+            android:icon="@mipmap/themed_icon"
             android:launchMode="singleTask"
             android:screenOrientation="userLandscape">
             <layout


### PR DESCRIPTION
Fixes regression from https://github.com/godotengine/godot/pull/99378. 

That PR modified the logic for themed icons, but the **Android Editor**'s manifest wasn't updated to reference the new `themed_icon.xml` which ended up disabling the themed icon for it.
