### PR TITLE
Update `issue template` to request Android device details when applicable

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -40,6 +40,14 @@ body:
     validations:
       required: true
 
+  - type: input
+    attributes:
+      label: Android device information (optional)
+      description: Please provide Android device details if the issue occurs on or is related to Android.
+      placeholder: Pixel 6 - Android 12 - Google Tensor - Mali-G78 MP20 - 8 GB RAM
+    validations:
+      required: false
+
   - type: textarea
     attributes:
       label: Issue description


### PR DESCRIPTION
Most issues related to Android are device-specific, but users often only provide details about the OS they are running the editor on.

This PR adds an _optional_ field in the issue template to request Android device details if applicable.

This would help in diagnosing Android related issues.